### PR TITLE
Material 3 switch in preferences

### DIFF
--- a/app/src/main/res/layout/item_setting_pref_switch.xml
+++ b/app/src/main/res/layout/item_setting_pref_switch.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Original source: https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/layout/preference_widget_switch.xml -->
+<!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!-- Layout used by SwitchPreference for the switch widget style. This is inflated
+     inside android.R.layout.preference. -->
+<androidx.appcompat.widget.SwitchCompat
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/switchWidget"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:focusable="false"
+    android:clickable="false"
+    android:background="@null"/>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -14,6 +14,8 @@
         <item name="materialAlertDialogTheme">@style/ThemeOverlay.MaterialAlertDialog.BlurBehind
         </item>
         <item name="bottomSheetDialogTheme">@style/ThemeOverlay.BottomSheetDialog.BlurBehind</item>
+        <!-- Make SwitchPreferenceCompat use Material 3 switch -->
+        <item name="preferenceTheme">@style/ThemeOverlay.Preference</item>
     </style>
 
     <style name="Theme.EasterEggs" parent="Base.EasterEggs">
@@ -135,6 +137,14 @@
 
     <style name="Theme.BottomSheet.Modal" parent="Widget.Material3.BottomSheet.Modal">
         <item name="backgroundTint">?attr/colorSurface</item>
+    </style>
+
+    <style name="ThemeOverlay.Preference" parent="@style/PreferenceThemeOverlay">
+        <item name="switchPreferenceCompatStyle">@style/Widget.Preference.Switch</item>
+    </style>
+
+    <style name="Widget.Preference.Switch" parent="@style/Preference.SwitchPreferenceCompat.Material">
+        <item name="widgetLayout">@layout/item_setting_pref_switch</item>
     </style>
 
     <style name="Theme.EggGroup.PopupMenu.ListPopupWindow" parent="Widget.Material3.PopupMenu.ListPopupWindow">


### PR DESCRIPTION
Currently, the switch used in `PreferenceScreen` is of Material 2 style, this will make it **Material 3**.