### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pgyer.yml
+++ b/.github/workflows/pgyer.yml
@@ -16,6 +16,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/hushenghao/AndroidEasterEggs/security/code-scanning/6](https://github.com/hushenghao/AndroidEasterEggs/security/code-scanning/6)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged.

Best fix here: define workflow-level permissions with `contents: read` (minimum needed for `actions/checkout`). This preserves existing behavior while preventing unintended write scopes from inherited defaults.

**File/region to change:**
- `.github/workflows/pgyer.yml`
- Insert `permissions:` after the triggers (`on:` block) and before `concurrency:`.

No imports, methods, or dependencies are required; this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
