### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -3,6 +3,7 @@ name: Crowdin Synchronize
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 on:
   push:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,5 +1,9 @@
 name: Crowdin Synchronize
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/hushenghao/AndroidEasterEggs/security/code-scanning/8](https://github.com/hushenghao/AndroidEasterEggs/security/code-scanning/8)

Add an explicit `permissions` block in `.github/workflows/crowdin.yml` at the workflow root (best here since there is a single job).  
Use least privilege while preserving current behavior:

- `contents: write` (needed to push localization commits/branches)
- `pull-requests: write` (needed to open/update PRs)
- optionally `contents: read` would be insufficient because this workflow creates PR content/commits.

**Where to change:** directly after the workflow `name` and before `on:`.  
No imports, methods, or extra definitions are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
