### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   github-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hushenghao/AndroidEasterEggs/security/code-scanning/9](https://github.com/hushenghao/AndroidEasterEggs/security/code-scanning/9)

To fix this, add an explicit top-level `permissions:` block in `.github/workflows/release.yml` so all jobs inherit constrained `GITHUB_TOKEN` scopes by default.  
Best single change (minimal and safe per CodeQL recommendation) is to add:

- `permissions:`
  - `contents: read`

Place it at workflow root (after `on:` block, before `jobs:`), so both `github-release` and `play-store` jobs are covered without changing their behavior otherwise. This satisfies the static analysis requirement and documents baseline least privilege. If later a specific job needs write access, that can be added at job level explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
