### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,13 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   github-release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/hushenghao/AndroidEasterEggs/security/code-scanning/10](https://github.com/hushenghao/AndroidEasterEggs/security/code-scanning/10)

Add explicit `permissions` to `.github/workflows/release.yml`:

1. Set a restrictive workflow-level default:
   - `permissions:`
   - `contents: read`
   This applies to all jobs unless overridden.

2. Add a job-level override for `github-release` (the job using `GITHUB_TOKEN` for release operations), granting only what it likely needs:
   - `permissions:`
   - `contents: write`
   This preserves release functionality while keeping the `play-store` job read-only by inheritance.

Edit regions:
- Insert workflow-level permissions after the `on` trigger block and before `jobs:`.
- Insert job-level permissions under `github-release:` and before `runs-on:`.

No imports, methods, or dependencies are required (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
