### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hushenghao/AndroidEasterEggs/security/code-scanning/7](https://github.com/hushenghao/AndroidEasterEggs/security/code-scanning/7)

Add an explicit `permissions` block to `.github/workflows/pr.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal required permission is:

- `contents: read`

This preserves existing behavior (checkout + build) while enforcing least privilege for `GITHUB_TOKEN`.

Change location: in `.github/workflows/pr.yml`, insert the block after `concurrency` (or before `jobs`) so structure remains clear and valid YAML.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
